### PR TITLE
docs(example): fix the python syntax of the TODO list example

### DIFF
--- a/docs/md/shad4fast-example.md
+++ b/docs/md/shad4fast-example.md
@@ -62,7 +62,7 @@ def __ft__(self: Todo):
     status_cls = "absolute top-1.5 right-1"
     checked = Badge(
         Lucide("check", stroke_width="3", cls="size-4"),
-        cls=f"!bg-green-600 text-accent-foreground {status_cls} {"invisible" if not self.done else ''}",
+        cls=f"!bg-green-600 text-accent-foreground {status_cls} {'invisible' if not self.done else ''}", cls
     )
 
     return Card(


### PR DESCRIPTION
Hey there :wave: 

Great work :grin: 
I was trying out the very recent example you shared for the TODO list. I encountered a bug which is only about a small typo on string formatting that causes a crash.

This PR simply fixes that!